### PR TITLE
feat: add missing agoric asset in assetlist.json

### DIFF
--- a/packages/core/src/assets/assetlist.json
+++ b/packages/core/src/assets/assetlist.json
@@ -2799,6 +2799,34 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg"
       },
       "coingecko_id": "oraichain-token"
+    },
+    {
+      "description": "BLD is the token used to secure the Agoric chain through staking and to backstop Inter Protocol.",
+      "denom_units": [
+        {
+          "denom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
+          "exponent": 0,
+          "aliases": [
+            "ubld"
+          ]
+        },
+        {
+          "denom": "bld",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
+      "name": "Agoric",
+      "display": "bld",
+      "symbol": "BLD",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png"
+      },
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-320",
+        "source_denom": "ubld"
+      }
     }
   ]
 }


### PR DESCRIPTION
Asset info for the agoric token is missing from the `asset.json` list, resulting in error when querying for the relevant pool.